### PR TITLE
Propagate exit codes from child process

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -150,6 +150,7 @@ if (command === "external") {
       if (devOptions.watch) {
         console.log(`[esbuild-dev] child process stopped with code`, code);
       }
+      process.exitCode = code;
       child = undefined;
     };
 


### PR DESCRIPTION
Hi hyrious,

exit codes are not propagated from child processes. This means, that a script run by esbuild-dev cannot exit with a code indicating error.

Thanks for creating such a useful npm package :).